### PR TITLE
Remove HTTPS references for sources

### DIFF
--- a/bios/chef/cookbooks/Berksfile
+++ b/bios/chef/cookbooks/Berksfile
@@ -1,2 +1,2 @@
-source 'https://api.berkshelf.com'
+source 'http://api.berkshelf.com'
 cookbook 'bios', path: './bios/'

--- a/bios/crowbar_engine/barclamp_bios/Gemfile
+++ b/bios/crowbar_engine/barclamp_bios/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source "http://rubygems.org"
 
 # Declare your gem's dependencies in barclamp_bios.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and

--- a/ipmi/chef/cookbooks/Berksfile
+++ b/ipmi/chef/cookbooks/Berksfile
@@ -1,2 +1,2 @@
-source 'https://api.berkshelf.com'
+source 'http://api.berkshelf.com'
 cookbook 'ipmi', path: './ipmi/'

--- a/raid/crowbar_engine/barclamp_raid/Gemfile
+++ b/raid/crowbar_engine/barclamp_raid/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source "http://rubygems.org"
 
 # Declare your gem's dependencies in barclamp_raid.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and


### PR DESCRIPTION
We have a lot of places were we use HTTPS but don't need it.

HTTPS may be complicated by some corporate networks so it is good idea to avoid if possible