### PR TITLE
Multiple detached admin nets

### DIFF
--- a/bios/chef/cookbooks/bios/providers/update.rb
+++ b/bios/chef/cookbooks/bios/providers/update.rb
@@ -141,6 +141,12 @@ end
 # Returns false if we need to try again or on failure.
 #
 def wsman_update(product)
+  # XXX: I don't think works on multiple levels.
+  #
+  # Provisioner information - is retreived differently
+  # Other info - is not available.
+  #
+
   # Get the provisioner IP.
   require 'wsman'
   provisioners = search(:node, "roles:provisioner-server")

--- a/bios/chef/cookbooks/bios/recipes/bios-install.rb
+++ b/bios/chef/cookbooks/bios/recipes/bios-install.rb
@@ -15,22 +15,7 @@
 
 include_recipe "bios::bios-common"
 
-provisioner_server = (node[:crowbar_wall][:provisioner_server] rescue nil)
-if (provisioner_server == nil)
-  provisioners = search(:node, "roles:provisioner-server")
-  provisioner = provisioners[0] if provisioners
-  if (provisioner != nil)
-    web_port = provisioner["provisioner"]["web_port"]
-    address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(provisioner, "admin").address
-    provisioner_server = "#{address}:#{web_port}"
-    log("Provisioner server info is #{provisioner_server}")
-    node[:crowbar_wall][:provisioner_server] = provisioner_server
-    node.save 
-  else
-    log("Provisioner server info could not be retrieved")
-  end
-end
-return unless provisioner_server
+provisioner_server = node[:crowbar][:provisioner][:server][:webservers].first
 
 include_recipe "bios::bios-tools"
 

--- a/bios/chef/cookbooks/bios/recipes/bios-tools.rb
+++ b/bios/chef/cookbooks/bios/recipes/bios-tools.rb
@@ -19,8 +19,8 @@
 
 include_recipe "bios::bios-common"
 
-provisioner_server = (node[:crowbar_wall][:provisioner_server] rescue nil)
-return unless provisioner_server
+provisioner_server = node[:crowbar][:provisioner][:server][:webservers].first
+
 bmc="bmc-2013-10-22.tgz"
 setupbios="setupbios-2013-10-03.tgz"
 socflash="socflash_v10601.zip"

--- a/bios/crowbar.yml
+++ b/bios/crowbar.yml
@@ -36,6 +36,7 @@ roles:
       - discovery
     requires:
       - deployer-client
+      - provisioner-service
     attribs:
       - name: set-mapping
         map: 'bios/set_mapping'
@@ -46,6 +47,8 @@ roles:
       - name: bios-config-sets
         map: 'bios/config_sets'
         description: 'The permitted BIOS configurations for this node.'
+    wants-attribs:
+      - provisioner-webservers
   - name: bios-dell-rseries-configure
     jig: role-provided
     requires:

--- a/ipmi/chef/cookbooks/ipmi/recipes/configure.rb
+++ b/ipmi/chef/cookbooks/ipmi/recipes/configure.rb
@@ -61,7 +61,7 @@ cmd_list << "lan set #{chan} access on" unless node["quirks"].member?("ipmi-cros
 
 ruby_block "Set IPMI credentials and enable LAN channel access" do
   block do
-     cmd_list.each do |cmd|
+    cmd_list.each do |cmd|
       IPMI.tool(node,cmd)
       raise "Failed to run #{cmd}" unless $?.exitstatus == 0
     end
@@ -94,11 +94,10 @@ if node[:ipmi][:use_dhcp]
   end unless lan_current_cfg['ipsrc'] == "dhcp"
 else
   lan_cfg = Mash.new
-  lan_cfg['ipsrc'] = node[:ipmi][:use_dhcp] ? "dhcp" : "static"
+  lan_cfg['ipsrc'] = "static"
 
   address = nil
-  node[:crowbar][:network][:addresses].each do |addr,opts|
-    next unless opts[:conduit] == "bmc"
+  node[:ipmi][:network].each do |addr,opts|
     address = IP.coerce(addr)
     lan_cfg['vlan id'] = opts[:use_vlan] ? opts[:vlan].to_s : "off"
     lan_cfg['ipaddr'] = address.addr

--- a/ipmi/crowbar.yml
+++ b/ipmi/crowbar.yml
@@ -41,8 +41,6 @@ hammers:
 roles:
   - name: ipmi-master
     jig: chef
-    requires:
-      - network-bmc
     flags:
       - bootstrap
   - name: ipmi-discover

--- a/ipmi/crowbar.yml
+++ b/ipmi/crowbar.yml
@@ -100,7 +100,7 @@ roles:
       - ipmi-discover
       - ipmi-master
     wants-attribs:
-      - provisioner-webserver
+      - provisioner-webservers
       - provisioner-proxy
       - ipmi-enable
       - ipmi-detected-params

--- a/ipmi/crowbar.yml
+++ b/ipmi/crowbar.yml
@@ -93,13 +93,9 @@ roles:
   - name: ipmi-configure
     jig: chef
     requires:
-      - network-bmc
-      - provisioner-repos
       - ipmi-discover
       - ipmi-master
     wants-attribs:
-      - provisioner-webservers
-      - provisioner-proxy
       - ipmi-enable
       - ipmi-detected-params
     attribs:

--- a/ipmi/crowbar_engine/barclamp_ipmi/app/models/barclamp_ipmi/discover.rb
+++ b/ipmi/crowbar_engine/barclamp_ipmi/app/models/barclamp_ipmi/discover.rb
@@ -22,10 +22,19 @@ class BarclampIpmi::Discover < Role
       Rails.logger.info("BMC not enabled on #{nr.node.name}")
       return
     end
+
     # If we do not have a BMC network defined, we cannot continue.
-    bmcnet = Network.find_by(name: "bmc")
+    # lookup up a BMC network-based upon the category/group of the admin network.
+    group_name = 'default'
+    NetworkAllocation.node(nr.node).each do |na|
+      if na.network.category == 'admin'
+        group_name = na.network.group
+        break
+      end
+    end
+    bmcnet = Network.find_by(category: "bmc", group: group_name)
     unless bmcnet
-      Rails.logger.info("No BMC network created.")
+      Rails.logger.info("No BMC network created for #{group_name}.")
       return
     end
 

--- a/raid/chef/cookbooks/raid/recipes/install_tools.rb
+++ b/raid/chef/cookbooks/raid/recipes/install_tools.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-raid_utils = "#{node[:crowbar][:provisioner][:server][:webserver]}/files/raid"
+raid_utils = "http://#{node[:crowbar][:provisioner][:server][:webservers].first}/files/raid"
 
 %w{unzip rpm2cpio curl}.each do |pkg|
   next if system("which #{pkg}")

--- a/raid/crowbar.yml
+++ b/raid/crowbar.yml
@@ -25,6 +25,7 @@ roles:
     jig: chef
     requires:
       - deployer-client
+      - provisioner-service
     flags:
       - implicit
     attribs:
@@ -36,7 +37,7 @@ roles:
         map: 'raid/drivers'
         ui_renderer: 'barclamp_raid/attribs/raid_tools_install'
     wants-attribs:
-      - provisioner-webserver
+      - provisioner-webservers
   - name: raid-discover
     jig: raid
     flags:


### PR DESCRIPTION
See the core for full details.

This updates the IPMI system to use  network groups to allocate bmc addresses.

This depends upon the provisioner-service work.