### PR TITLE
Make sure that the known disk info gets reloaded after raid-configure…

### DIFF
--- a/raid/chef/roles/raid-post-configure.rb
+++ b/raid/chef/roles/raid-post-configure.rb
@@ -1,0 +1,17 @@
+# Copyright (c) 2015, RackN.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name "raid-post-configure"
+description "Grab updated disk configuration after RAID messes with the volumes"
+run_list()

--- a/raid/crowbar.yml
+++ b/raid/crowbar.yml
@@ -154,6 +154,12 @@ roles:
       - name: raid-configured-volumes
         description: "The current RAID volumes on this node"
         map: 'raid/volumes/configured'
+  - name: raid-post-configure
+    jig: chef
+    requires:
+      - raid-configure
+    flags:
+      - implicit
 hammers:
   - name: raid-hammer
     type: 'BarclampRaid::RaidHammer'

--- a/raid/crowbar_engine/barclamp_raid/app/models/barclamp_raid/discover.rb
+++ b/raid/crowbar_engine/barclamp_raid/app/models/barclamp_raid/discover.rb
@@ -29,12 +29,12 @@ class BarclampRaid::Discover < Role
 
     # Since we have detected controllers we can manage, go ahead and bind the
     # raid-configure and crowbar-hardware-configured roles to this node.
-    rcr_role = Role.find_by!(name: 'raid-configure')
+    rpc_role = Role.find_by!(name: 'raid-post-configure')
     chc_role = Role.find_by!(name: 'crowbar-hardware-configured')
     NodeRole.transaction do
-      rcr_noderole = rcr_role.add_to_node(nr.node)
+      rpc_noderole = rpc_role.add_to_node(nr.node)
       chc_noderole = chc_role.add_to_node(nr.node)
-      rcr_noderole.add_child(chc_noderole)
+      rpc_noderole.add_child(chc_noderole)
     end
   end
 end


### PR DESCRIPTION
… runs.

This should prevent the OS installation onto unknown volume issues we
were sseeing.