### PR TITLE
Make the IPMI hammer have priority over WSMAN

### DIFF
--- a/ipmi/crowbar.yml
+++ b/ipmi/crowbar.yml
@@ -32,7 +32,7 @@ crowbar:
 
 hammers:
   - name: ipmi
-    priority: 1
+    priority: 6
     type: 'BarclampIpmi::IpmiHammer'
   - name: wsman
     priority: 2


### PR DESCRIPTION
The openwsman library does not play nice with threading in Ruby,
apparently, so prefer IPMI over WSMAN where they have overlapping
functionality.